### PR TITLE
Module 15: fix outdated and unverifiable supplementary sources

### DIFF
--- a/Curriculum/15 - Security of and for AI/15.03 - Supplementary Reading Materials.md
+++ b/Curriculum/15 - Security of and for AI/15.03 - Supplementary Reading Materials.md
@@ -10,13 +10,18 @@ The [OWASP LLM Prompt Injection Prevention Cheat Sheet](https://cheatsheetseries
 
 ### Input Validation
 
-[LLM Input Sanitizer](https://pypi.org/project/llm-input-sanitizer) is a Python library that offers LLM-specific features like PII detection and masking, profanity filtering, input truncation, Unicode normalization, prompt injection defense and jailbreak prevention.
+Filtering and classifying model input reduces exposure to known attack patterns, but it does not create a trust boundary.
+A large language model has no reliable way to separate instructions from data, so input handling on its own cannot prevent prompt injection.
+The [OWASP LLM Prompt Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html) treats input filtering as necessary but not sufficient, and pairs it with least privilege for the application, rate limiting, output validation, and human approval for high-risk operations.
 
-More traditional guidance that is not specific to AI can also be applied to large language models. For example, OWASP Annotated Application Security Verification Standard includes a [chapter on Sanitization and Sandboxing Requirements](https://owasp-aasvs4.readthedocs.io/en/latest/V5.html#validation-sanitization-and-encoding), which covers requirements that apply to AI models, in addition to other types of applications.
+Guidance that is not specific to AI also applies to applications built on large language models.
+The [OWASP Application Security Verification Standard 5.0.0: V1 Encoding and Sanitization](https://github.com/OWASP/ASVS/blob/v5.0.0/5.0/en/0x10-V1-Encoding-and-Sanitization.md) chapter defines encoding and sanitization requirements that apply to model input and output in the same way they apply to any other untrusted data.
 
 ### Output Data Control
 
-Improper Output Handling is [number 05 of the OWASP LLM Top 10](https://genai.owasp.org/llmrisk/llm052025-improper-output-handling). This section of the OWASP GenAI Security Project includes common examples of the vulnerability, prevention and mitigation strategies, example attack scenarios and references to other relevant resources. 
+Model output is untrusted input to whatever consumes it, whether that is a browser, a shell, a database driver, or another service.
+Improper Output Handling is [LLM10 in the OWASP GenAI LLM Top 10 2026](https://genai.owasp.org/resource/owasp-genai-llm-top-10-2026/), where it also covers insecure code produced by coding assistants.
+The entry lists common examples of the vulnerability, prevention and mitigation strategies, example attack scenarios, and references to other relevant resources.
 
 ### Model Theft and Extraction
 


### PR DESCRIPTION
While going through Module 15 I checked each external source. Three don't hold up. This PR fixes those.

### The PyPI package

The Input Validation section recommended `llm-input-sanitizer` by name. It's at 0.2.1, the author field is "Alex", and the GitHub repository it declares as its home page is gone: https://github.com/alexu8007/llm-input-sanitizer

Module 10 of this curriculum teaches developers to verify the provenance of a dependency before pulling it in. Naming a pre-1.0 package with no reachable source repository five modules later undercuts that. I've replaced the recommendation with the point it was standing in for (filtering input isn't a trust boundary) and cited the OWASP LLM Prompt Injection Prevention Cheat Sheet, which makes the same argument and pairs filtering with least privilege, rate limiting and human approval for high-risk operations.

### The ASVS reference

The same section linked the Annotated ASVS v4 on readthedocs. Modules 2, 3, 4 and 9 all cite ASVS 5.0.0, and that chapter was renumbered from V5 to V1 between the two versions, so the link text didn't match its target either. Switched to ASVS 5.0.0 V1 Encoding and Sanitization, in the same link format the other modules use.

### "number 05 of the OWASP LLM Top 10"

Improper Output Handling was LLM05 in the 2025 edition. In the 2026 edition, published 4 August 2026, it's LLM10, and it now also covers insecure code produced by coding assistants. Fixed the rank and the link.

That one is the small end of a larger problem. 15.01 still lists all ten 2025 entries. I'll open an issue for that.
